### PR TITLE
Set flag ShuffleDriverComponents.supportsReliableStorage to true

### DIFF
--- a/src/main/scala/org/apache/spark/shuffle/S3ShuffleDataIO.scala
+++ b/src/main/scala/org/apache/spark/shuffle/S3ShuffleDataIO.scala
@@ -65,5 +65,9 @@ class S3ShuffleDataIO(sparkConf: SparkConf) extends ShuffleDataIO {
     override def removeShuffle(shuffleId: Int, blocking: Boolean): Unit = {
       super.removeShuffle(shuffleId, blocking)
     }
+
+    override def supportsReliableStorage(): Boolean = {
+      true
+    }
   }
 }


### PR DESCRIPTION
This change fixes the issue with rerunning map tasks on lost executors.
It is described here https://issues.apache.org/jira/browse/SPARK-26268